### PR TITLE
Fix Python 3.6 unknown escape build error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_version_from_pc(search_dirs, target):
         for root, dirs, files in os.walk(dirname):
             for f in files:
                 if f == target:
-                    _tmp = _grep("\Version: ", os.path.join(root, target))
+                    _tmp = _grep("Version: ", os.path.join(root, target))
                     return _tmp.split()[1]
 
 


### PR DESCRIPTION
In Python 3.6, unknown regex escape sequences are now errors, this patch updates the setup.py to avoid that error. I checked that this patch does not affect Python2 builds.

Reference:
https://docs.python.org/3.6/library/re.html#regular-expression-syntax (The note is at the end of the section)