### PR TITLE
fix to avoid UnicodeDecodeError when accesing Blob.data in Python3

### DIFF
--- a/src/_Blob.cpp
+++ b/src/_Blob.cpp
@@ -18,11 +18,19 @@ static void update_wrapper(Magick::Blob& blob, const std::string& data) {
     blob.update(data.c_str(),data.size());
 }
 
+#if PY_MAJOR_VERSION >= 3
+static object get_blob_data(const Magick::Blob& blob) {
+    const char* data = static_cast<const char*>(blob.data());
+    size_t length = blob.length();
+    return object(handle<>(PyBytes_FromStringAndSize(data, length)));
+}
+#else
 static std::string get_blob_data(const Magick::Blob& blob) {
     const char* data = static_cast<const char*>(blob.data());
     size_t length = blob.length();
     return std::string(data,data+length);
 }
+#endif
 
 
 void __Blob()


### PR DESCRIPTION
Boost.Python converts std::string to Python's str type, which is a byte-string in Python2 (and is suitable for binary data) but unicode text in Python3. It means that attempts to access Blob.data in Python3 will raise UnicodeDecodeError.  
  
This pull request solves the problem by changing get_blob_data function (Blob.data getter) to returning bytes in Python3.