### PR TITLE
Support GM 1.3.26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,8 @@ if _version:
         _version.append(0)
     if LIBRARY == 'GraphicsMagick':
         ext_compile_args = []
+        if _version[0] == 1 and _version[1] == 3 and _version[2] >= 26:
+            ext_compile_args.append("-DPGMAGICK_LIB_GRAPHICSMAGICK_1_3_26")
         if _version[0] == 1 and _version[1] == 3 and _version[2] >= 24:
             ext_compile_args.append("-DPGMAGICK_LIB_GRAPHICSMAGICK_1_3_24")
         if _version[0] == 1 and _version[1] == 3 and _version[2] >= 22:

--- a/src/_Image.cpp
+++ b/src/_Image.cpp
@@ -292,7 +292,11 @@ void __Image()
         .def("animationIterations", (void (Magick::Image::*)(const unsigned int) )&Magick::Image::animationIterations)
         .def("animationIterations", (unsigned int (Magick::Image::*)() const)&Magick::Image::animationIterations)
 #endif
+#ifdef PGMAGICK_LIB_GRAPHICSMAGICK_1_3_26
+        .def("attribute", (void (Magick::Image::*)(const std::string, const char*) )&Magick::Image::attribute)
+#else
         .def("attribute", (void (Magick::Image::*)(const std::string, const std::string) )&Magick::Image::attribute)
+#endif
         .def("attribute", (std::string (Magick::Image::*)(const std::string) )&Magick::Image::attribute)
         .def("backgroundColor", (void (Magick::Image::*)(const Magick::Color&) )&Magick::Image::backgroundColor)
         .def("backgroundColor", (Magick::Color (Magick::Image::*)() const)&Magick::Image::backgroundColor)


### PR DESCRIPTION
GraphicsMagick 1.3.26 was released, see https://sourceforge.net/p/graphicsmagick/mailman/message/35927958/

It includes new feature
> Magick++: Added Image attribute method which accepts a 'char *' argument, and will remove the attribute if the value argument is NULL.

This PR enables access to this new signature from 1.3.26 onwards.