### PR TITLE
Refactor -DPGMAGICK_LIB_GRAPHICSMAGICK detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 install:
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2."* ]]; then sudo /usr/bin/python setup.py install; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" == "3."* ]]; then sudo mkdir -p /usr/lib/python3.4/site-packages/ ; sudo /usr/bin/python3 setup.py install; fi
-    - if [[ "$TARGET" == "macosx2" ]]; then python setup.py install; fi
+    - if [[ "$TARGET" == "macosx2" ]]; then python2 setup.py install; fi
     - if [[ "$TARGET" == "macosx3" ]]; then python3 setup.py install; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ install:
 script:
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2."* ]]; then PYTHON=/usr/bin/python make test; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" == "3."* ]]; then PYTHON=/usr/bin/python3 make test; fi
-    - if [[ "$TARGET" == "macosx2" ]]; then PYTHON=`which python` make test; fi
+    - if [[ "$TARGET" == "macosx2" ]]; then PYTHON=`which python2` make test; fi
     - if [[ "$TARGET" == "macosx3" ]]; then PYTHON=`which python3` make test; fi
     - ls setup.py

--- a/setup.py
+++ b/setup.py
@@ -158,12 +158,9 @@ if _version:
         _version.append(0)
     if LIBRARY == 'GraphicsMagick':
         # 1.3.6 for not Ubuntu10.04
-        _tested_api_versions = ((1,3,26), (1,3,24), (1,3,22), (1,3,20), (1,3,19), (1,3,6))
+        _tested_api_versions = ((1,3,26), (1,3,24), (1,3,22), (1,3,20), (1,3,19), (1,3,6), (1,3,'x'))
         _supported_api_versions = (v for v in _tested_api_versions if library_supports_api(_version, v))
         ext_compile_args = ["-DPGMAGICK_LIB_GRAPHICSMAGICK_" + '_'.join(map(str, version)) for version in _supported_api_versions]
-        if not (_version[0] == 1 and _version[1] == 1):
-            # for GM version 1.3.x and higher
-            ext_compile_args.append("-DPGMAGICK_LIB_GRAPHICSMAGICK_1_3_x")
     elif LIBRARY == 'ImageMagick':
         ext_compile_args = ["-DPGMAGICK_LIB_IMAGEMAGICK"]
     ext_compile_args.append("-D_LIBRARY_VERSION=\"%s\"" % (_str_version))

--- a/setup.py
+++ b/setup.py
@@ -159,8 +159,8 @@ if _version:
     if LIBRARY == 'GraphicsMagick':
         # 1.3.6 for not Ubuntu10.04
         _tested_api_versions = ((1,3,26), (1,3,24), (1,3,22), (1,3,20), (1,3,19), (1,3,6))
-        _supportedApiVersions = (v for v in _tested_api_versions if library_supports_api(_version, v))
-        ext_compile_args = ["-DPGMAGICK_LIB_GRAPHICSMAGICK_" + '_'.join(map(str, version)) for version in _supportedApiVersions]
+        _supported_api_versions = (v for v in _tested_api_versions if library_supports_api(_version, v))
+        ext_compile_args = ["-DPGMAGICK_LIB_GRAPHICSMAGICK_" + '_'.join(map(str, version)) for version in _supported_api_versions]
         if not (_version[0] == 1 and _version[1] == 1):
             # for GM version 1.3.x and higher
             ext_compile_args.append("-DPGMAGICK_LIB_GRAPHICSMAGICK_1_3_x")


### PR DESCRIPTION
Use new function library_supports_api that will provide easy way to support different major and minor versions in the future instead of repeated code (imagine the conditions needed if GM 1.4 or 2.0 would be released).

It also allows adding new GM version support just by changing one line - by adding version to _tested_api_versions.

Detecting -DPGMAGICK_LIB_GRAPHICSMAGICK_1_3_x leaving as special case - it is either bad packaging for some distribution (GM 1.3 packaged as 1.1) or an undetected bug - not sure, so not touching it.

Just a proposal, not necessary to merge - looking forward for your opinion.