### PR TITLE
Fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include Makefile
 include src/Makefile
 include LICENSE
 include README.rst
+recursive-include example *

--- a/test/test_pgmagick_api.py
+++ b/test/test_pgmagick_api.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import unittest
 import sys
 sys.path.append('../')
@@ -17,15 +19,9 @@ class ImageTestCase(unittest.TestCase):
 
     def test_unicodefilename(self):
         self.img.write('unicode.png')
-        if sys.version_info >= (3, ):
-            img = Image('unicode.png')
-        else:
-            img = Image(unicode('unicode.png'))
+        img = Image(u'unicode.png')
         img.scale(0.5)
-        if sys.version_info >= (3, ):
-            img.write('unicode.jpg')
-        else:
-            img.write(unicode('unicode.jpg'))
+        img.write(u'unicode.jpg')
 
     def test_nonarg(self):
         Image()

--- a/test/test_pgmagick_libinfo.py
+++ b/test/test_pgmagick_libinfo.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+
 from pgmagick import gminfo as info
 
 libinfo = info()
-print libinfo.version
-print libinfo.library
+print(libinfo.version)
+print(libinfo.library)


### PR DESCRIPTION
**Make codebase fully Py2/Py3 compatible**

* Python 3.3 reintroduced the u'' prefix, which is
  more generalisable than a conditional on Py3
* Tested with Py2.7/3.4/3.5/3.6

**Add `example/` dir to MANIFEST.in**

* The PyPI tarballs lack the `example/` dir,
  which leads to test failures.
