### PR TITLE
Make color histogram accessible from Image

### DIFF
--- a/src/_Image.cpp
+++ b/src/_Image.cpp
@@ -1,7 +1,10 @@
 #include <boost/python.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/python/suite/indexing/map_indexing_suite.hpp>
+#include <map>
 
 #include <Magick++/Image.h>
+#include <Magick++/STL.h>
 
 #include "_Pixels.h"
 
@@ -57,9 +60,20 @@ PixelPacketArrayProxy set_pixels(Magick::Image* image, int x, int y, unsigned in
     return PixelPacketArrayProxy(cache, columns*rows, *image);
 }
 
+std::map<Magick::Color,unsigned long> get_color_histogram(const Magick::Image image) {
+    std::map<Magick::Color,unsigned long> histogram;
+    colorHistogram( &histogram, image );
+    return histogram;
+}
+
 void __Image()
 {
     def("InitializeMagick", Magick::InitializeMagick);
+
+    class_<std::map<Magick::Color, unsigned long> >("ColorHistogram")
+         .def(boost::python::map_indexing_suite<std::map<Magick::Color, unsigned long> >())
+    ;
+
     class_< Magick::Image >("Image", init<  >())
         .def(init< const std::string& >())
         .def(init< const Magick::Geometry&, const Magick::Color& >())
@@ -343,6 +357,7 @@ void __Image()
         .def("clipMask", (Magick::Image (Magick::Image::*)() const)&Magick::Image::clipMask)
         .def("colorFuzz", (void (Magick::Image::*)(const double) )&Magick::Image::colorFuzz)
         .def("colorFuzz", (double (Magick::Image::*)() const)&Magick::Image::colorFuzz)
+        .def("colorHistogram", &get_color_histogram)
 #ifdef PGMAGICK_LIB_IMAGEMAGICK
         .def("colorMap", (void (Magick::Image::*)(const size_t, const Magick::Color&) )&Magick::Image::colorMap)
         .def("colorMap", (Magick::Color (Magick::Image::*)(const size_t) const)&Magick::Image::colorMap)

--- a/test/test_pgmagick_image.py
+++ b/test/test_pgmagick_image.py
@@ -95,6 +95,19 @@ class TestImage(unittest.TestCase):
         im.resize(g, ft)
         im.resize(g)
 
+    def test_color_histogram(self):
+        redColor = Color('red')
+        im = Image(Geometry(30, 20), redColor)
+        histogram = im.colorHistogram()
+        self.assertEqual(1, len(histogram))
+        # test in, __getitem__
+        self.assertIn(redColor, histogram)
+        self.assertEqual(30 * 20, histogram[redColor])
+        # iteration example
+        for packet in histogram:
+            color, count = packet.key(), packet.data()
+            self.assertEqual(redColor, color)
+            self.assertEqual(30 * 20, count)
 
 class TestIMImage(unittest.TestCase):
 


### PR DESCRIPTION
This commit enables getting a color histogram for given image.

Because function colorHistogram from Magick++'s STL.h must always be called with an image as an argument, I propose to expose it as an Image method in Python interface.

I've chosen map<Color, int> (color->count) as an underlying container - nonetheless after wrapping in map_indexing_suite the access in Python is IMHO clumsy but allows for lookup in the histogram.
Another option would be to use a vector of pairs as the container - we would lose the ability for simple lookup by color, but would gain simpler iteration and possibility to construct dict from tuples in python if needed. Finally, we can return boost::python::dict - but it means to create map first and copy-construct dict.

Looking forward to your opinion.