### PR TITLE
fix compile warning

### DIFF
--- a/src/_ArrayProxy.h
+++ b/src/_ArrayProxy.h
@@ -38,12 +38,8 @@ private:
 
   size_type checkIndex(size_type index) const
   {
-    // Adjust negative index.
-    if (index < 0)
-        index += length;
-
     // Boundary check.
-    if (index < 0 || index >= length) {
+    if (index >= length) {
       PyErr_SetString(PyExc_IndexError, "Index out of range");
       boost::python::throw_error_already_set();
     }


### PR DESCRIPTION
fix to this compile warning:
```
In file included from ./src/_Image.cpp:9:
In file included from ./src/_Pixels.h:5:
./src/_ArrayProxy.h:42:15: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
    if (index < 0)
        ~~~~~ ^ ~
```

 size_t is unsigned.