### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ setup(name='pgmagick',
       packages=find_packages(),
       ext_modules=[
           Extension('pgmagick._pgmagick',
-                    sources=glob.glob('./src/*.cpp'),
+                    sources=sorted(glob.glob('./src/*.cpp')),
                     include_dirs=include_dirs,
                     library_dirs=library_dirs,
                     libraries=libraries,


### PR DESCRIPTION
so that pgmagick builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.