### PR TITLE
Support M1 Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,13 @@ search_include_dirs = ['/usr/local/include/GraphicsMagick/',
                        '/usr/include/GraphicsMagick/']
 search_library_dirs = ['/usr/local/lib64/', '/usr/lib64/',
                        '/usr/local/lib/', '/usr/lib/']
-search_pkgconfig_dirs = ['/usr/local/lib/pkgconfig/', '/usr/local/lib64/pkgconfig/',
-                         '/usr/lib/pkgconfig/', '/usr/lib64/pkgconfig']
+search_pkgconfig_dirs = [
+    '/opt/homebrew/lib/pkgconfig',
+    '/usr/local/lib/pkgconfig/',
+    '/usr/local/lib64/pkgconfig/',
+    '/usr/lib/pkgconfig/',
+    '/usr/lib64/pkgconfig',
+]
 if sys.platform.lower() == 'darwin':
     if os.path.exists('/opt/local/include'):
         include_dirs.append('/opt/local/include/')
@@ -36,8 +41,10 @@ if sys.platform.lower() == 'darwin':
         include_dirs.append('/usr/local/include/')
     search_include_dirs.extend(['/opt/local/include/GraphicsMagick/',
                                 '/opt/local/include/',
+                                '/opt/homebrew/include/GraphicsMagick',
                                 '/usr/local/Cellar/graphicsmagick'])
     search_library_dirs.extend(['/opt/local/lib/',
+                                '/opt/homebrew/lib',
                                 '/usr/local/Cellar/graphicsmagick'])
 # for ImageMagick
 search_include_dirs.extend(['/usr/local/include/ImageMagick/',


### PR DESCRIPTION
## How about this?
Fixes #67 

## implementation
* Add `/opt/homebrew`, the default Homebrew's installation path
  for M1 mac, to the build file search path.

refs: https://github.com/Homebrew/brew/blob/master/docs/Installation.md#alternative-installs
> However do yourself a favour and install to `/usr/local` on macOS Intel, `/opt/homebrew` on macOS ARM,
and `/home/linuxbrew/.linuxbrew` on Linux. Some things may
not build when installed elsewhere. One of the reasons Homebrew just
works relative to the competition is **because** we recommend installing
here. *Pick another prefix at your peril!*

## release plan
version 0.7.6, asap