### PR TITLE
Python 3.14 support:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,7 @@ def version():
     with io.open('pgmagick/_version.py') as input_file:
         for line in input_file:
             if line.startswith('__version__'):
-                return ast.parse(line).body[0].value.s
+                return ast.parse(line).body[0].value.value
     raise NotImplementedError("invalid version file")
 
 


### PR DESCRIPTION
The AST Constant `.s` attribute was replaced by `.value` See: https://github.com/python/cpython/issues/119562